### PR TITLE
Ignore the vagrant created directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant


### PR DESCRIPTION
This ignores any `.vagrant` folders created after running `vagrant up` the first time.
